### PR TITLE
Move @types/sortablejs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@types/sortablejs": "^1.15.0",
     "sortablejs": "^1.15.0"
   },
   "peerDependencies": {
     "solid-js": ">=1.0.0"
   },
   "devDependencies": {
-    "@types/sortablejs": "^1.15.0",
     "prettier": "2.8.3",
     "rollup": "^3.28.1",
     "rollup-preset-solid": "^2.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "strict": true,
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
@@ -16,6 +20,11 @@
     "types": [],
     "baseUrl": "."
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Issue: https://github.com/Nerimity/solid-sortablejs/pull/2#issuecomment-1839366493

Solution: https://stackoverflow.com/questions/45176661/how-do-i-decide-whether-types-goes-into-dependencies-or-devdependencies

### Test:
```console
pnpm add github:tennox/solid-sortablejs
```