### PR TITLE
fix types export for modern style definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "require": "./dist/cjs/index.js"
       },
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
In a modern vite environment, this style is used and I figured I forgot the type export there too :face_with_spiral_eyes: 